### PR TITLE
feat(cli): live YAML output (-n) and remove interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,54 @@
 # Cligent
 
-Unified SDK for CLI agents (Claude Code, Gemini CLI, Qwen Coder). Parse, select, and compose messages from AI agent session logs with support for YAML export/import.
+Unified SDK for CLI agents (Claude Code, Gemini CLI, Qwen Coder, Codex CLI). Parse, select, and compose messages from AI agent session logs with support for YAML export/import.
 
 ## Features
 
-- **Multi-Agent Support**: Works with Claude Code, Gemini CLI, and Qwen Coder
+- **Multi-Agent Support**: Works with Claude Code, Gemini CLI, Qwen Coder, and Codex CLI
 - **Session Log Parsing**: Extract conversations from JSONL log files
 - **Message Selection**: Select specific messages from conversations
 - **YAML Export/Import**: Convert messages to/from Tigs YAML format
-- **Interactive CLI**: Built-in command-line interface for testing
 - **Project-Aware**: Automatically finds logs for current project directory
 
-## Quick Start
+## Installation
 
-### Installation
+See per-language installation guides:
 
-```bash
-# Clone the repository
-git clone https://github.com/your-repo/cligent.git
-cd cligent
-
-# Install dependencies
-pip install -r requirements.txt
-```
+- Python: python/README.md
 
 ## Language Implementations
 
 - Python: see python/README.md
 
-### Python API
+## Supported Agents
 
+| Agent | Description | Log Location                             |
+|-------|-------------|------------------------------------------|
+| **claude** | Claude Code sessions | `~/.claude/projects/` (project-specific) |
+| **gemini** | Gemini CLI conversations | `~/.gemini/logs/`                        |
+| **qwen** | Qwen Coder sessions | `~/.qwen/sessions/`                      |
+| **codex** | Codex CLI sessions | `~/.codex/sessions/`                     |
+
+## API Reference
+
+### Core Classes
+
+- **`Cligent`**: Abstract base class for all agents
+- **`Chat`**: Collection of messages representing a conversation
+- **`Message`**: Individual message with role, content, and metadata
+- **`Role`**: Enum for message roles (USER, ASSISTANT, SYSTEM)
+
+### Key Methods
+
+- **`create(agent_type)`**: Factory function to create agent instances
+- **`parse(log_uri=None)`**: Parse conversation from log (None = most recent)
+- **`list_logs()`**: List available conversation logs with metadata
+- **`select(log_uri, indices=None)`**: Select messages for composition
+- **`compose(*args)`**: Export messages to Tigs YAML format
+- **`decompose(yaml_string)`**: Import messages from Tigs YAML format
+- **`clear_selection()`**: Clear currently selected messages
+
+Example:
 ```python
 from src import create
 
@@ -56,48 +75,6 @@ with open("conversation.yaml", "r") as f:
 loaded_chat = agent.decompose(yaml_content)
 print(f"Loaded {len(loaded_chat.messages)} messages from YAML")
 ```
-
-### Interactive CLI
-
-```bash
-python example_usage.py
-```
-
-The CLI provides commands for:
-- **list**: Show available conversation logs
-- **parse**: Parse a specific conversation
-- **live**: Parse the most recent conversation
-- **select**: Select messages for composition
-- **compose**: Export selected messages to YAML
-- **decompose**: Load messages from YAML file
-- **clear**: Clear message selection
-
-## Supported Agents
-
-| Agent | Description | Log Location |
-|-------|-------------|--------------|
-| **claude** | Claude Code sessions | `~/.claude/tmp/` (project-specific) |
-| **gemini** | Gemini CLI conversations | `~/.gemini/logs/` |
-| **qwen** | Qwen Coder sessions | `~/.qwen/sessions/` |
-
-## API Reference
-
-### Core Classes
-
-- **`Cligent`**: Abstract base class for all agents
-- **`Chat`**: Collection of messages representing a conversation
-- **`Message`**: Individual message with role, content, and metadata
-- **`Role`**: Enum for message roles (USER, ASSISTANT, SYSTEM)
-
-### Key Methods
-
-- **`create(agent_type)`**: Factory function to create agent instances
-- **`parse(log_uri=None)`**: Parse conversation from log (None = most recent)
-- **`list_logs()`**: List available conversation logs with metadata
-- **`select(log_uri, indices=None)`**: Select messages for composition
-- **`compose(*args)`**: Export messages to Tigs YAML format
-- **`decompose(yaml_string)`**: Import messages from Tigs YAML format
-- **`clear_selection()`**: Clear currently selected messages
 
 ### YAML Format
 

--- a/python/README.md
+++ b/python/README.md
@@ -10,26 +10,6 @@ selecting, and composing messages across supported providers.
 pip install cligent
 ```
 
-## CLI
-
-After installation, the `cligent` command is available:
-
-```bash
-# List recent logs for a provider
-cligent --agent codex list
-
-# Parse a specific log URI
-cligent --agent codex parse 2025/10/01/rollout-...jsonl
-
-# Parse the most recent (live) log
-cligent --agent codex live
-
-# Interactive REPL
-cligent interactive
-```
-
-Providers: `claude`, `gemini`, `qwen`, `codex`.
-
 ## Python API
 
 ```python
@@ -49,6 +29,26 @@ loaded = agent.decompose(yaml_text)
 pip install -e .[dev]
 pytest -q
 ```
+
+### CLI
+
+After installation, the `cligent` command is available:
+
+```bash
+# List recent logs for a provider
+cligent --agent codex list
+
+# Parse a specific log URI
+cligent --agent codex parse 2025/10/01/rollout-...jsonl
+
+# Show the last N messages (e.g., 5) from the live (most recent) log
+cligent --agent codex live -n 5
+
+# Help
+cligent --help
+```
+
+Providers: `claude`, `gemini`, `qwen`, `codex`.
 
 ## Package Structure
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -31,3 +31,28 @@ def test_cli_parse_codex(monkeypatch, capsys):
     assert code == 0
     assert "Parsed 2 messages" in captured.out
 
+
+def test_cli_live_codex_shows_yaml(capsys):
+    mock_home = Path(__file__).parent / "mock_codex_home"
+    mock_cwd = Path("/workspace/sample/project")
+    with patch.object(Path, "home", return_value=mock_home), \
+         patch.object(Path, "cwd", return_value=mock_cwd):
+        code = main(["--agent", "codex", "live"])  # default -n=10
+    out = capsys.readouterr().out
+    assert code == 0
+    assert out.startswith("schema: tigs.chat/v1")
+    assert "messages:" in out
+    assert "role: assistant" in out
+
+
+def test_cli_live_codex_n_1_limits_output(capsys):
+    mock_home = Path(__file__).parent / "mock_codex_home"
+    mock_cwd = Path("/workspace/sample/project")
+    with patch.object(Path, "home", return_value=mock_home), \
+         patch.object(Path, "cwd", return_value=mock_cwd):
+        code = main(["--agent", "codex", "live", "-n", "1"])  # only last message
+    out = capsys.readouterr().out
+    assert code == 0
+    assert out.startswith("schema: tigs.chat/v1")
+    # Ensure assistant role present and only one message block present heuristically
+    assert "role: assistant" in out


### PR DESCRIPTION
Enhance the trial/debug CLI and docs for clarity and consistency.

Overview
- `cligent live` now renders the last N messages as Tigs YAML using `compose()` so live output matches our standard export format.
- Add `-n/--num` to control how many messages to show (default: 10).
- Remove the interactive REPL to keep the CLI explicit (subcommands only: `list`, `parse <uri>`, `live`). If no subcommand is provided, the CLI prints help and exits.

Changes
- CLI
  - Implement YAML output in `live` via `compose()`
  - Add `-n/--num` (default 10)
  - Remove the interactive REPL
- Tests
  - Update/add CLI tests to assert YAML output and `-n` behavior
- Docs
  - Root `README.md`: defer install steps to per‑language docs; add Codex CLI to supported providers
  - `python/README.md`: document `cligent live -n N` and clarify that live prints YAML

Rationale
- Align `live` output with our YAML export format for easier reuse, sharing, and tooling integration
- Reduce ambiguity by removing the REPL and relying on explicit subcommands

Compatibility
- Non‑breaking for the library/API
- CLI change: the old REPL entry was removed; users should call explicit subcommands (`list`, `parse`, `live`).

How to verify
- `cd python && uv pip install -e .[dev]`
- `uv run cligent --agent codex live` (prints YAML)
- `uv run cligent --agent codex live -n 5`
- `uv run pytest -q python/tests/test_cli.py`
