### PR TITLE
feat(logs): recursive listing and uri normalisation

### DIFF
--- a/python/src/agents/claude_code/core.py
+++ b/python/src/agents/claude_code/core.py
@@ -179,28 +179,62 @@ class ClaudeLogStore(LogStore):
         working_dir = Path.cwd()
         project_folder_name = str(working_dir.absolute()).replace("/", "-")
         claude_base = Path.home() / ".claude" / "projects"
+        self._projects_root = claude_base
         self._project_dir = claude_base / project_folder_name
 
         # Override the default logs directory for Claude's structure
         self._logs_dir = self._project_dir
         self.project_folder_name = project_folder_name
 
-    def list(self) -> List[Tuple[str, Dict[str, Any]]]:
-        """Show available session logs for the current project."""
+    def list(self, recursive: bool = True) -> List[Tuple[str, Dict[str, Any]]]:
+        """Show available session logs.
+
+        When recursive is True (default), include logs from any Claude
+        project directories whose names start with this project's
+        prefix. URIs in recursive mode are relative paths under the
+        projects root (e.g., "Users-me-proj-python/log.jsonl"). In
+        non-recursive mode, URIs are session IDs (filename stems).
+        """
         logs = []
 
         try:
-            if not self._project_dir.exists():
-                return logs
+            if recursive:
+                # Aggregate across all project dirs that start with this prefix
+                root = getattr(self, "_projects_root", None)
+                if root and root.exists():
+                    base = self.project_folder_name
+                    for proj_dir in root.iterdir():
+                        if not proj_dir.is_dir():
+                            continue
+                        name = str(proj_dir.name)
+                        if not name.startswith(base):
+                            continue
+                        # Derive URI prefix from suffix after base ('-sub' -> 'sub')
+                        suffix = name[len(base):]
+                        if suffix.startswith('-'):
+                            suffix = suffix[1:]
+                        else:
+                            suffix = ''
+                        uri_prefix = suffix.replace('-', '/') if suffix else ''
+                        for log_file in proj_dir.glob("*.jsonl"):
+                            if not log_file.is_file():
+                                continue
+                            metadata = self._create_file_metadata(log_file)
+                            metadata["project"] = proj_dir.name
+                            uri = f"{uri_prefix}/{log_file.name}" if uri_prefix else log_file.name
+                            logs.append((uri, metadata))
+                else:
+                    # Fallback to non-recursive if root missing
+                    recursive = False
 
-            # Scan for JSONL files in this project's directory only
-            for log_file in self._project_dir.glob("*.jsonl"):
-                if log_file.is_file():
-                    metadata = self._create_file_metadata(log_file)
-                    metadata["project"] = self.project_folder_name
-                    # Use session ID (filename without path) as URI
-                    session_id = log_file.stem
-                    logs.append((session_id, metadata))
+            if not recursive:
+                if not self._project_dir.exists():
+                    return logs
+                for log_file in self._project_dir.glob("*.jsonl"):
+                    if log_file.is_file():
+                        metadata = self._create_file_metadata(log_file)
+                        metadata["project"] = self.project_folder_name
+                        logs.append((log_file.name, metadata))
 
         except (OSError, PermissionError):
             pass
@@ -209,13 +243,32 @@ class ClaudeLogStore(LogStore):
 
     def _resolve_log_path(self, log_uri: str) -> Path:
         """Resolve log URI to file path for Claude's structure."""
-        # Handle both session IDs and full paths for compatibility
+        # Handle URIs: either file name (no path sep) or relative
+        # paths under projects root based on the base project prefix.
         if "/" in log_uri or "\\" in log_uri:
-            # Full path provided (backwards compatibility)
-            return Path(log_uri)
-        else:
-            # Session ID provided - construct full path
-            return self._project_dir / f"{log_uri}.jsonl"
+            uri_path = Path(log_uri)
+            if uri_path.is_absolute():
+                raise FileNotFoundError(f"Session log file not found: {log_uri}")
+
+            parts = uri_path.parts
+            if not parts:
+                raise FileNotFoundError(f"Invalid session log URI: {log_uri}")
+            if any(part in {"", ".", ".."} for part in parts):
+                raise FileNotFoundError(f"Invalid session log URI: {log_uri}")
+
+            filename = parts[-1]
+            suffix_parts = list(parts[:-1])
+
+            if not suffix_parts:
+                project_dir = self._project_dir
+            else:
+                suffix = "-".join(suffix_parts)
+                project_dir = self._projects_root / f"{self.project_folder_name}-{suffix}"
+
+            return project_dir / filename
+
+        # File name provided - resolve in current project dir
+        return self._project_dir / log_uri
 
 
 class ClaudeCligent(Cligent):
@@ -237,15 +290,9 @@ class ClaudeCligent(Cligent):
         return ClaudeLogStore()
 
     def parse_content(self, content: str, log_uri: str) -> Chat:
-        # 使用现有的LogFile逻辑
-        if "/" in log_uri or "\\" in log_uri:
-            file_path = Path(log_uri)
-        else:
-            file_path = self.store._project_dir / f"{log_uri}.jsonl"
+        # Resolve via store to support both session IDs and relative paths
+        file_path = self.store._resolve_log_path(log_uri)
 
         log_file = ClaudeLogFile(file_path=file_path)
         log_file.load()
         return log_file.to_chat(log_uri=log_uri)
-
-
-

--- a/python/src/agents/claude_code/core.py
+++ b/python/src/agents/claude_code/core.py
@@ -289,8 +289,7 @@ class ClaudeCligent(Cligent):
     def _create_store(self) -> LogStore:
         return ClaudeLogStore()
 
-    def parse_content(self, content: str, log_uri: str) -> Chat:
-        # Resolve via store to support both session IDs and relative paths
+    def _parse_from_store(self, log_uri: str) -> Chat:
         file_path = self.store._resolve_log_path(log_uri)
 
         log_file = ClaudeLogFile(file_path=file_path)

--- a/python/src/agents/codex_cli/core.py
+++ b/python/src/agents/codex_cli/core.py
@@ -136,7 +136,7 @@ class CodexCligent(Cligent):
     def _create_store(self) -> LogStore:
         return CodexLogStore()
 
-    def parse_content(self, content: str, log_uri: str) -> Chat:
+    def _parse_from_store(self, log_uri: str) -> Chat:
         path_hint = Path(log_uri)
         if path_hint.is_absolute():
             file_path = path_hint

--- a/python/src/agents/codex_cli/core.py
+++ b/python/src/agents/codex_cli/core.py
@@ -82,7 +82,7 @@ class CodexLogStore(LogStore):
         sessions_dir = Path.home() / ".codex" / "sessions"
         self._logs_dir = sessions_dir
 
-    def list(self) -> List[Tuple[str, Dict[str, Any]]]:
+    def list(self, recursive: bool = True) -> List[Tuple[str, Dict[str, Any]]]:
         logs: List[Tuple[str, Dict[str, Any]]] = []
         if not self._logs_dir.exists():
             return logs

--- a/python/src/agents/gemini_cli/core.py
+++ b/python/src/agents/gemini_cli/core.py
@@ -154,7 +154,7 @@ class GeminiCligent(Cligent):
     def _create_store(self) -> LogStore:
         return GeminiLogStore()
 
-    def parse_content(self, content: str, log_uri: str) -> Chat:
+    def _parse_from_store(self, log_uri: str) -> Chat:
         # Handle new <uuid>/<file_name> format
         if "/" in log_uri and not log_uri.startswith("/"):
             # Format: <uuid>/<file_name>
@@ -175,4 +175,3 @@ class GeminiCligent(Cligent):
         log_file = GeminiLogFile(file_path=file_path)
         log_file.load()
         return log_file.to_chat(log_uri=log_uri)
-

--- a/python/src/agents/gemini_cli/core.py
+++ b/python/src/agents/gemini_cli/core.py
@@ -176,4 +176,3 @@ class GeminiCligent(Cligent):
         log_file.load()
         return log_file.to_chat(log_uri=log_uri)
 
-

--- a/python/src/agents/gemini_cli/core.py
+++ b/python/src/agents/gemini_cli/core.py
@@ -177,4 +177,3 @@ class GeminiCligent(Cligent):
         return log_file.to_chat(log_uri=log_uri)
 
 
-

--- a/python/src/agents/qwen_code/core.py
+++ b/python/src/agents/qwen_code/core.py
@@ -122,6 +122,13 @@ class QwenLogStore(LogStore):
 
     def _resolve_log_path(self, log_uri: str) -> Path:
         """Resolve log URI to file path for Qwen's structure."""
+        # Treat filenames with extensions directly within logs dir
+        candidate = Path(log_uri)
+        if candidate.suffix in {".json", ".jsonl"} and not log_uri.startswith("/") and "\\" not in log_uri and "/" not in log_uri:
+            resolved = self._logs_dir / candidate
+            if resolved.exists():
+                return resolved
+
         # Handle new <uuid>/<file_name> format
         if "/" in log_uri and not log_uri.startswith("/"):
             # Format: <uuid>/<file_name>
@@ -196,6 +203,5 @@ class QwenCligent(Cligent):
         log_file = QwenLogFile(file_path=file_path)
         log_file.load()
         return log_file.to_chat(log_uri=log_uri)
-
 
 

--- a/python/src/agents/qwen_code/core.py
+++ b/python/src/agents/qwen_code/core.py
@@ -174,7 +174,7 @@ class QwenCligent(Cligent):
     def _create_store(self) -> LogStore:
         return QwenLogStore()
 
-    def parse_content(self, content: str, log_uri: str) -> Chat:
+    def _parse_from_store(self, log_uri: str) -> Chat:
         # Handle new <uuid>/<file_name> format
         if "/" in log_uri and not log_uri.startswith("/"):
             # Format: <uuid>/<file_name>
@@ -203,5 +203,4 @@ class QwenCligent(Cligent):
         log_file = QwenLogFile(file_path=file_path)
         log_file.load()
         return log_file.to_chat(log_uri=log_uri)
-
 

--- a/python/src/cligent.py
+++ b/python/src/cligent.py
@@ -53,13 +53,13 @@ class Cligent(ABC):
         return self._store
 
     # Log Parsing Methods
-    def list_logs(self) -> List[Tuple[str, Dict[str, Any]]]:
+    def list_logs(self, recursive: bool = True) -> List[Tuple[str, Dict[str, Any]]]:
         """Show available logs for the agent.
 
         Returns:
             List of (log_uri, metadata) tuples
         """
-        return self.store.list()
+        return self.store.list(recursive=recursive)
 
     def parse(self, log_uri: str = None) -> Chat:
         """Extract chat from specific or live session log.

--- a/python/src/cligent.py
+++ b/python/src/cligent.py
@@ -38,8 +38,8 @@ class Cligent(ABC):
         pass
 
     @abstractmethod
-    def parse_content(self, content: str, log_uri: str) -> 'Chat':
-        """Parse raw log content into Chat object."""
+    def _parse_from_store(self, log_uri: str) -> 'Chat':
+        """Load and parse a chat from persisted logs."""
         pass
 
 
@@ -71,14 +71,12 @@ class Cligent(ABC):
             Parsed Chat object
         """
         if log_uri:
-            content = self.store.get(log_uri)
-            return self.parse_content(content, log_uri)
-        else:
-            live_uri = self.store.live()
-            if live_uri is None:
-                return None
-            content = self.store.get(live_uri)
-            return self.parse_content(content, live_uri)
+            return self._parse_from_store(log_uri)
+
+        live_uri = self.store.live()
+        if live_uri is None:
+            return None
+        return self._parse_from_store(live_uri)
 
     def compose(self, *args) -> str:
         """Create Tigs text output from selected content.

--- a/python/src/core/models.py
+++ b/python/src/core/models.py
@@ -399,8 +399,19 @@ class LogStore:
         # Default to logs directory
         return base_dir / "logs"
 
-    def list(self) -> List[Tuple[str, Dict[str, Any]]]:
-        """Show available session logs."""
+    def list(self, recursive: bool = True) -> List[Tuple[str, Dict[str, Any]]]:
+        """Show available session logs.
+
+        Args:
+            recursive: Hint for providers that support hierarchical or
+                project-scoped layouts. If True (default), providers may
+                include logs from sub-scopes related to the current
+                workspace. If False, providers should restrict results to
+                the most specific scope (e.g., exact project directory).
+
+        Returns:
+            List of (log_uri, metadata) tuples.
+        """
         logs = []
 
         try:
@@ -416,7 +427,7 @@ class LogStore:
             for pattern in self.config.log_patterns:
                 for log_file in self._logs_dir.glob(pattern):
                     if log_file.is_file():
-                        logs.append(self._create_log_entry(log_file, log_file.stem))
+                        logs.append(self._create_log_entry(log_file))
 
         except (OSError, PermissionError):
             pass
@@ -441,14 +452,14 @@ class LogStore:
 
         return logs
 
-    def _create_log_entry(self, log_file: Path, session_id: str) -> Tuple[str, Dict[str, Any]]:
+    def _create_log_entry(self, log_file: Path) -> Tuple[str, Dict[str, Any]]:
         """Create a log entry tuple."""
         metadata = self._create_file_metadata(log_file)
         metadata.update({
             "file_name": log_file.name,
-            "session_id": session_id
+            "session_id": log_file.stem
         })
-        return (session_id, metadata)
+        return (log_file.name, metadata)
 
     def _create_file_metadata(self, file_path: Path) -> Dict[str, Any]:
         """Create metadata dict for a file."""

--- a/python/tests/test_claude_recursive.py
+++ b/python/tests/test_claude_recursive.py
@@ -1,0 +1,73 @@
+"""Tests for Claude Code recursive listing behavior.
+
+These tests verify that when treating CWD as a prefix, list(recursive=True)
+aggregates logs from all project folders whose names start with the current
+project prefix, and that recursive=False restricts to the exact project.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from src.agents.claude_code.core import ClaudeLogStore
+
+
+def _write_jsonl(file: Path) -> None:
+    file.parent.mkdir(parents=True, exist_ok=True)
+    file.write_text(
+        "\n".join(
+            [
+                '{"timestamp":"2025-01-01T00:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Hi"}]}}',
+                '{"timestamp":"2025-01-01T00:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}}',
+            ]
+        )
+    )
+
+
+def test_claude_recursive_listing(tmp_path: Path) -> None:
+    # Arrange projects root
+    projects_root = tmp_path / ".claude" / "projects"
+
+    # Base project is '...-python'; sub project is '...-python-utils'
+    cwd_python = Path("/home/user/projects/myproject/python")
+    base = str(cwd_python).replace("/", "-")
+    proj_base = projects_root / base
+    proj_utils = projects_root / f"{base}-utils"
+
+    f1 = proj_base / "log1.jsonl"
+    f2 = proj_utils / "log2.jsonl"
+    _write_jsonl(f1)
+    _write_jsonl(f2)
+
+    # When recursive=True (default), both logs are listed relative to root
+    with patch.object(Path, "home", return_value=tmp_path), \
+         patch.object(Path, "cwd", return_value=cwd_python):
+        store = ClaudeLogStore()
+        logs = store.list()  # default recursive
+
+    uris = {uri for uri, _ in logs}
+    # Base project file should be just the filename
+    assert "log1.jsonl" in uris
+    # Subproject should appear with path prefix derived from suffix
+    assert "utils/log2.jsonl" in uris
+
+
+def test_claude_nonrecursive_listing(tmp_path: Path) -> None:
+    # Arrange projects root and a specific sub-project (python)
+    projects_root = tmp_path / ".claude" / "projects"
+    cwd_python = Path("/home/user/projects/myproject/python")
+    base = str(cwd_python).replace("/", "-")
+    proj_python = projects_root / base
+
+    f1 = proj_python / "only.jsonl"
+    _write_jsonl(f1)
+
+    with patch.object(Path, "home", return_value=tmp_path), \
+         patch.object(Path, "cwd", return_value=cwd_python):
+        store = ClaudeLogStore()
+        logs = store.list(recursive=False)
+
+    # Non-recursive returns filenames (no path separators)
+    assert logs, "Expected at least one log in non-recursive listing"
+    for uri, _ in logs:
+        assert "/" not in uri and "\\" not in uri
+        assert uri == f1.name

--- a/python/tests/test_qwen_code.py
+++ b/python/tests/test_qwen_code.py
@@ -365,8 +365,8 @@ class TestQwenLogStore:
         
         assert len(logs) == 2
         session_ids = [log[0] for log in logs]
-        assert "session1" in session_ids
-        assert "session2" in session_ids
+        assert "session1.jsonl" in session_ids
+        assert "session2.jsonl" in session_ids
         
         # Check metadata structure
         metadata = logs[0][1]
@@ -387,7 +387,7 @@ class TestQwenLogStore:
         """Test retrieving log content by session ID."""
         with patch('pathlib.Path.home', return_value=mock_home_dir):
             store = QwenLogStore()
-            content = store.get("session1")
+            content = store.get("session1.jsonl")
         
         assert content == '{"content": "test1", "model": "qwen"}'
 
@@ -407,7 +407,7 @@ class TestQwenLogStore:
             store = QwenLogStore()
             
             with pytest.raises(FileNotFoundError, match="Session log file not found"):
-                store.get("nonexistent")
+                store.get("nonexistent.jsonl")
 
     def test_live_log(self, mock_home_dir):
         """Test getting most recent log."""
@@ -416,7 +416,7 @@ class TestQwenLogStore:
             live_log = store.live()
         
         # Should return one of the sessions (most recent)
-        assert live_log in ["session1", "session2"]
+        assert live_log in ["session1.jsonl", "session2.jsonl"]
 
     def test_live_log_no_logs(self, tmp_path):
         """Test getting live log when no logs exist."""


### PR DESCRIPTION
## Summary
- **Claude recursive listings** – `Cligent.list_logs()` now takes a `recursive`
  flag (default `True`). Claude’s store looks for sibling project folders whose
  names start with the CWD-derived prefix and emits relative URIs such as
  `utils/log1.jsonl` (base project still returns `log1.jsonl`). URIs are
  sanitised (no `..`, no absolute paths) and resolve back to
  `~/.claude/projects/<base>-utils/log1.jsonl`.
- **URI normalisation** – every provider now returns filenames with
  extensions. Examples: `simple_chat.jsonl` (Claude non-recursive),
  `2025/10/01/rollout-....jsonl` (Codex), `session-123/checkpoint.json`
  (Gemini/Qwen). Tests were updated to reflect this uniform shape.
- **Parser hook simplification** – replaced the old `parse_content(content,
  log_uri)` with `_parse_from_store(log_uri)`. Providers load their log once via
  the new hook, avoiding redundant reads, while `LogStore.get()` remains
  available for raw-text scenarios (CLI/debugging).
- **Test refresh** – Claude tests now exercise `ChatParser("claude-code")`
  end-to-end, selecting URIs like `simple_chat.jsonl`, and a new
  `test_claude_recursive.py` asserts recursive vs. non-recursive behaviour.

## Examples
- Recursive listing from `/home/user/projects/myproject/python` yields:
  - `simple_chat.jsonl`
  - `utils/log2.jsonl`
- Non-recursive listing yields:
  - `simple_chat.jsonl`
- Parsing via parser:
  ```python
  parser = ChatParser("claude-code")
  chat = parser.parse("simple_chat.jsonl")
  ```

## Testing
- `cd python && uv run pytest`
